### PR TITLE
Graphql time bucket queries

### DIFF
--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -60,5 +60,11 @@ module Types
     description: "Url for comment"
     field :tags, String, null: true,
     description: "Comment tags"
+
+    # output fields
+    field :bucket, GraphQL::Types::ISO8601DateTime, null: true,
+    description: "BucketQuery output time slot"
+    field :count, Int, null: true,
+    description: "BucketQuery output event count"
   end
 end

--- a/app/graphql/types/event_type.rb
+++ b/app/graphql/types/event_type.rb
@@ -62,9 +62,9 @@ module Types
     description: "Comment tags"
 
     # output fields
-    field :bucket, GraphQL::Types::ISO8601DateTime, null: true,
-    description: "BucketQuery output time slot"
+    field :period, GraphQL::Types::ISO8601DateTime, null: true,
+    description: "Output time slot"
     field :count, Int, null: true,
-    description: "BucketQuery output event count"
+    description: "Output event count"
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -32,5 +32,16 @@ module Types
     def user_bucket_query(kwargs, searcher=Searchers::Bucket)
       searcher.new.search(**kwargs)
     end
+
+    field :project_bucket_query, [Types::EventType], null: false do
+      description 'returns bucketed counts of events by project in category'
+      argument :project_id, ID, required: true
+      argument :event_type, String, required: true
+      argument :time_bucket, String, required: true
+    end
+
+    def project_bucket_query(kwargs, searcher=Searchers::Bucket)
+      searcher.new.search(**kwargs)
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -23,10 +23,10 @@ module Types
     end
 
     field :user_stats_count, [Types::EventType], null: false do
-      description 'returns bucketed counts of events by user in category'
+      description 'returns counts of events by user in category grouped into period with length of interval (i.e. "1 day")'
       argument :user_id, ID, required: true
       argument :event_type, String, required: true
-      argument :time_bucket, String, required: true
+      argument :interval, String, required: true
     end
 
     def user_stats_count(kwargs, searcher=Searchers::Bucket)
@@ -34,10 +34,10 @@ module Types
     end
 
     field :project_stats_count, [Types::EventType], null: false do
-      description 'returns bucketed counts of events by project in category'
+      description 'returns counts of events by project in category grouped into period with length of interval (i.e. "1 day")'
       argument :project_id, ID, required: true
       argument :event_type, String, required: true
-      argument :time_bucket, String, required: true
+      argument :interval, String, required: true
     end
 
     def project_stats_count(kwargs, searcher=Searchers::Bucket)

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -21,5 +21,16 @@ module Types
     def project_id_query(kwargs, searcher=Searchers::Complete)
       searcher.new.search(**kwargs)
     end
+
+    field :user_bucket_query, [Types::EventType], null: false do
+      description 'returns bucketed counts of events by user in category'
+      argument :user_id, ID, required: true
+      argument :event_type, String, required: true
+      argument :time_bucket, String, required: true
+    end
+
+    def user_bucket_query(kwargs, searcher=Searchers::Bucket)
+      searcher.new.search(**kwargs)
+    end
   end
 end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -22,25 +22,25 @@ module Types
       searcher.new.search(**kwargs)
     end
 
-    field :user_bucket_query, [Types::EventType], null: false do
+    field :user_stats_count, [Types::EventType], null: false do
       description 'returns bucketed counts of events by user in category'
       argument :user_id, ID, required: true
       argument :event_type, String, required: true
       argument :time_bucket, String, required: true
     end
 
-    def user_bucket_query(kwargs, searcher=Searchers::Bucket)
+    def user_stats_count(kwargs, searcher=Searchers::Bucket)
       searcher.new.search(**kwargs)
     end
 
-    field :project_bucket_query, [Types::EventType], null: false do
+    field :project_stats_count, [Types::EventType], null: false do
       description 'returns bucketed counts of events by project in category'
       argument :project_id, ID, required: true
       argument :event_type, String, required: true
       argument :time_bucket, String, required: true
     end
 
-    def project_bucket_query(kwargs, searcher=Searchers::Bucket)
+    def project_stats_count(kwargs, searcher=Searchers::Bucket)
       searcher.new.search(**kwargs)
     end
   end

--- a/app/graphql/utilities/searchers.rb
+++ b/app/graphql/utilities/searchers.rb
@@ -4,4 +4,11 @@ module Searchers
       Event.where(**kwargs)
     end
   end
+
+  class Bucket
+    def search(kwargs)
+      time_bucket = kwargs.delete(:time_bucket)
+      Event.select("time_bucket('#{time_bucket}', event_time) AS bucket, count(*)").group("bucket").where(**kwargs)
+    end
+  end
 end

--- a/app/graphql/utilities/searchers.rb
+++ b/app/graphql/utilities/searchers.rb
@@ -8,7 +8,7 @@ module Searchers
   class Bucket
     def search(kwargs)
       time_bucket = kwargs.delete(:time_bucket)
-      Event.select("time_bucket('#{time_bucket}', event_time) AS bucket, count(*)").group("bucket").where(**kwargs)
+      Event.select("time_bucket('#{time_bucket}', event_time) AS period, count(*)").group("period").where(**kwargs)
     end
   end
 end

--- a/app/graphql/utilities/searchers.rb
+++ b/app/graphql/utilities/searchers.rb
@@ -7,7 +7,7 @@ module Searchers
 
   class Bucket
     def search(kwargs)
-      time_bucket = kwargs.delete(:time_bucket)
+      time_bucket = kwargs.delete(:interval)
       Event.select("time_bucket('#{time_bucket}', event_time) AS period, count(*)").group("period").where(**kwargs)
     end
   end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,10 @@
 # Load the Rails application.
 require_relative 'application'
 
+# Add the utilities folder to the autoload path
+Rails.application.configure do
+  config.autoload_paths << "#{Rails.root}/app/graphql/utilities"
+end
+
 # Initialize the Rails application.
 Rails.application.initialize!

--- a/spec/graphql/types/event_type_spec.rb
+++ b/spec/graphql/types/event_type_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Types::EventType do
     'body'               => 'String',
     'url'                => 'String',
     'tags'               => 'String',
+
+    # output fields
+    'bucket'             => 'ISO8601DateTime',
+    'count'              => 'Int',
   }.each do |field_name, expected_field_type|
     it '' do
       field_info = subject.fields[field_name]

--- a/spec/graphql/types/event_type_spec.rb
+++ b/spec/graphql/types/event_type_spec.rb
@@ -38,10 +38,10 @@ RSpec.describe Types::EventType do
     'tags'               => 'String',
 
     # output fields
-    'bucket'             => 'ISO8601DateTime',
+    'period'             => 'ISO8601DateTime',
     'count'              => 'Int',
   }.each do |field_name, expected_field_type|
-    it '' do
+    it "has matching field: #{field_name}" do
       field_info = subject.fields[field_name]
       expect(field_info.type.to_type_signature).to eq(expected_field_type)
       expect(field_info.description).not_to be_nil

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -1,19 +1,24 @@
 RSpec.describe Types::QueryType do
   subject { Types::QueryType }
 
-  # 'queryName'         => 'Output_type', {
-  #   'argumentName'    => 'Argument_type' }
+  # 'queryName'           => 'Output_type', {
+  #   'argumentName'      => 'Argument_type' }
   {
-    'userIdQuery'       => ['[Event!]!', {
-      'userId'          => 'ID!'
+    'userIdQuery'         => ['[Event!]!', {
+      'userId'            => 'ID!'
     }],
-    'projectIdQuery'    => ['[Event!]!', {
-      'projectId'       => 'ID!'
+    'projectIdQuery'      => ['[Event!]!', {
+      'projectId'         => 'ID!'
     }],
-    'userBucketQuery'   => ['[Event!]!', {
-      'userId'          => 'ID!',
-      'eventType'       => 'String!',
-      'timeBucket'      => 'String!'
+    'userBucketQuery'     => ['[Event!]!', {
+      'userId'            => 'ID!',
+      'eventType'         => 'String!',
+      'timeBucket'        => 'String!'
+    }],
+    'projectBucketQuery'  => ['[Event!]!', {
+      'projectId'            => 'ID!',
+      'eventType'         => 'String!',
+      'timeBucket'        => 'String!'
     }]
   }.each do |field_name, expected_results|
     (expected_field_type, expected_arguments) = expected_results

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe Types::QueryType do
     'userStatsCount'     => ['[Event!]!', {
       'userId'            => 'ID!',
       'eventType'         => 'String!',
-      'timeBucket'        => 'String!'
+      'interval'        => 'String!'
     }],
     'projectStatsCount'  => ['[Event!]!', {
       'projectId'            => 'ID!',
       'eventType'         => 'String!',
-      'timeBucket'        => 'String!'
+      'interval'        => 'String!'
     }]
   }.each do |field_name, expected_results|
     (expected_field_type, expected_arguments) = expected_results

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe Types::QueryType do
     'projectIdQuery'      => ['[Event!]!', {
       'projectId'         => 'ID!'
     }],
-    'userBucketQuery'     => ['[Event!]!', {
+    'userStatsCount'     => ['[Event!]!', {
       'userId'            => 'ID!',
       'eventType'         => 'String!',
       'timeBucket'        => 'String!'
     }],
-    'projectBucketQuery'  => ['[Event!]!', {
+    'projectStatsCount'  => ['[Event!]!', {
       'projectId'            => 'ID!',
       'eventType'         => 'String!',
       'timeBucket'        => 'String!'

--- a/spec/graphql/types/query_type_spec.rb
+++ b/spec/graphql/types/query_type_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Types::QueryType do
     }],
     'projectIdQuery'    => ['[Event!]!', {
       'projectId'       => 'ID!'
+    }],
+    'userBucketQuery'   => ['[Event!]!', {
+      'userId'          => 'ID!',
+      'eventType'       => 'String!',
+      'timeBucket'      => 'String!'
     }]
   }.each do |field_name, expected_results|
     (expected_field_type, expected_arguments) = expected_results

--- a/spec/graphql/utilities/searchers_spec.rb
+++ b/spec/graphql/utilities/searchers_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Searchers do
     let(:time_bucket) { '1 day' }
     let(:arguments) do
       {
-        time_bucket:    time_bucket,
+        interval:    time_bucket,
         user_id:        users_id,
         event_type:     event_types
       }

--- a/spec/graphql/utilities/searchers_spec.rb
+++ b/spec/graphql/utilities/searchers_spec.rb
@@ -57,15 +57,15 @@ RSpec.describe Searchers do
       it 'returns the expected buckets' do
         expected = [
           {
-            "bucket"  => start_time.midnight,
+            "period"  => start_time.midnight,
             "count"   => 1
           },
           {
-            "bucket"  => mid_time.midnight,
+            "period"  => mid_time.midnight,
             "count"   => 2
           },
           {
-            "bucket"  => end_time.midnight,
+            "period"  => end_time.midnight,
             "count"   => 3
           }
         ]

--- a/spec/graphql/utilities/searchers_spec.rb
+++ b/spec/graphql/utilities/searchers_spec.rb
@@ -1,3 +1,5 @@
+require_relative '../../../app/graphql/utilities/searchers.rb'
+
 RSpec.describe Searchers do
   subject(:complete_searcher) { Searchers::Complete.new }
 
@@ -16,6 +18,59 @@ RSpec.describe Searchers do
       it 'returns the expected events only' do
         results = complete_searcher.search(user_id: users_id)
         expect(results).to match_array(events)
+      end
+    end
+  end
+
+  subject(:bucket_searcher) { Searchers::Bucket.new }
+
+  describe 'bucketing events for a specific :userId or :projectId with a specific event_type' do
+    let(:users_id) { 123 }
+    let(:event_types) { 'classification' }
+    let(:time_bucket) { '1 day' }
+    let(:arguments) do
+      {
+        time_bucket:    time_bucket,
+        user_id:        users_id,
+        event_type:     event_types
+      }
+    end
+    let(:start_time) { Time.zone.parse('2018-11-06 10:30:10') }
+    let!(:generic_classifications) { create_list(:event, 3, event_time: start_time, event_type: 'classification') }
+    let!(:generic_comments) { create_list(:event, 3, event_time: start_time, event_type: 'comment') }
+
+    context 'when there are no events by that user' do
+      it 'returns no buckets' do
+        results = bucket_searcher.search(**arguments)
+        expect(results).to match_array([])
+      end
+    end
+
+    context 'when there are events by that user' do
+      let(:mid_time) { start_time + 2.day }
+      let(:end_time) { mid_time + 2.day }
+      before(:each) do
+        create_list(:event, 1, user_id: users_id, event_time: start_time, event_type: event_types)
+        create_list(:event, 2, user_id: users_id, event_time: mid_time, event_type: event_types)
+        create_list(:event, 3, user_id: users_id, event_time: end_time, event_type: event_types)
+      end
+      it 'returns the expected buckets' do
+        expected = [
+          {
+            "bucket"  => start_time.midnight,
+            "count"   => 1
+          },
+          {
+            "bucket"  => mid_time.midnight,
+            "count"   => 2
+          },
+          {
+            "bucket"  => end_time.midnight,
+            "count"   => 3
+          }
+        ]
+        results = bucket_searcher.search(**arguments).map(&:attributes)
+        expect(results).to match_array(expected)
       end
     end
   end

--- a/spec/graphql/utilities/searchers_spec.rb
+++ b/spec/graphql/utilities/searchers_spec.rb
@@ -1,5 +1,3 @@
-require_relative '../../../app/graphql/utilities/searchers.rb'
-
 RSpec.describe Searchers do
   subject(:complete_searcher) { Searchers::Complete.new }
 

--- a/spec/graphql/zoo_stats_schema_spec.rb
+++ b/spec/graphql/zoo_stats_schema_spec.rb
@@ -101,7 +101,7 @@ Rspec.describe ZooStatsSchema do
     event_type = 'classification'
     time_bucket = '1 day'
     query_string = "{
-      userStatsCount(userId: #{user_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
+      userStatsCount(userId: #{user_id}, eventType: \"#{event_type}\", interval: \"#{time_bucket}\"){
         period,
         count
       }
@@ -119,7 +119,7 @@ Rspec.describe ZooStatsSchema do
     event_type = 'classification'
     time_bucket = '1 day'
     query_string = "{
-      projectStatsCount(projectId: #{project_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
+      projectStatsCount(projectId: #{project_id}, eventType: \"#{event_type}\", interval: \"#{time_bucket}\"){
         period,
         count
       }

--- a/spec/graphql/zoo_stats_schema_spec.rb
+++ b/spec/graphql/zoo_stats_schema_spec.rb
@@ -112,4 +112,22 @@ Rspec.describe ZooStatsSchema do
     ]
     it_behaves_like 'a graphQL query', query_name, query_string, output
   end
+
+  describe 'projectBucketQuery' do
+    query_name = 'projectBucketQuery'
+    project_id= 456
+    event_type = 'classification'
+    time_bucket = '1 day'
+    query_string = "{
+      projectBucketQuery(projectId: #{project_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
+        bucket,
+        count
+      }
+    }"
+    output = [
+      {"bucket"=>"2018-11-06T00:00:00Z", "count"=>1},
+      {"bucket"=>"2018-11-08T00:00:00Z", "count"=>2}
+    ]
+    it_behaves_like 'a graphQL query', query_name, query_string, output
+  end
 end

--- a/spec/graphql/zoo_stats_schema_spec.rb
+++ b/spec/graphql/zoo_stats_schema_spec.rb
@@ -102,13 +102,13 @@ Rspec.describe ZooStatsSchema do
     time_bucket = '1 day'
     query_string = "{
       userBucketQuery(userId: #{user_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
-        bucket,
+        period,
         count
       }
     }"
     output = [
-      {"bucket"=>"2018-11-06T00:00:00Z", "count"=>1},
-      {"bucket"=>"2018-11-08T00:00:00Z", "count"=>2}
+      {"period"=>"2018-11-06T00:00:00Z", "count"=>1},
+      {"period"=>"2018-11-08T00:00:00Z", "count"=>2}
     ]
     it_behaves_like 'a graphQL query', query_name, query_string, output
   end
@@ -120,13 +120,13 @@ Rspec.describe ZooStatsSchema do
     time_bucket = '1 day'
     query_string = "{
       projectBucketQuery(projectId: #{project_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
-        bucket,
+        period,
         count
       }
     }"
     output = [
-      {"bucket"=>"2018-11-06T00:00:00Z", "count"=>1},
-      {"bucket"=>"2018-11-08T00:00:00Z", "count"=>2}
+      {"period"=>"2018-11-06T00:00:00Z", "count"=>1},
+      {"period"=>"2018-11-08T00:00:00Z", "count"=>2}
     ]
     it_behaves_like 'a graphQL query', query_name, query_string, output
   end

--- a/spec/graphql/zoo_stats_schema_spec.rb
+++ b/spec/graphql/zoo_stats_schema_spec.rb
@@ -1,72 +1,84 @@
 RSpec.shared_examples 'a graphQL query' do |query_name, query_string, output|
-    let(:context) { {} }
-    let(:variables) { {} }
-    # Call `result` to execute the query
-    let(:result) {
-      res = ZooStatsSchema.execute(
-        query_string,
-        context: context,
-        variables: variables
-      )
-      # Print any errors
-      if res["errors"]
-        pp res
-      end
-      res
+  let(:context) { {} }
+  let(:variables) { {} }
+  # Call `result` to execute the query
+  let(:result) {
+    res = ZooStatsSchema.execute(
+      query_string,
+      context: context,
+      variables: variables
+    )
+    # Print any errors
+    if res["errors"]
+      pp res
+    end
+    res
+  }
+  let(:query_string) { query_string }
+  let(:base_attributes) do
+    {
+      event_id:   1,
+      event_type: 'classification'
     }
-    let(:query_string) { query_string }
-    let(:base_attributes) do
-      {
-        event_id:   1
-      }
-    end
-    let(:attributes_type_0) do
-      base_attributes.merge({
-        user_id:    111,
-        project_id: 222
-      })
-    end
-    let(:attributes_type_1) do
-      base_attributes.merge({
-        user_id:    123,
-        project_id: 456,
-      })
-    end
-    let!(:events_type_0) { create_list(:event, 3, **attributes_type_0) }
+  end
+  let(:attributes_type_0) do
+    base_attributes.merge({
+      user_id:    111,
+      project_id: 222,
+    })
+  end
+  let(:start_time) { Time.zone.parse('2018-11-06 05:45:09') }
+  let(:attributes_type_1) do
+    base_attributes.merge({
+      user_id:    123,
+      project_id: 456,
+      event_time: start_time,
+    })
+  end
+  let(:mid_time) { start_time + 2.day }
+  let(:attributes_type_2) do
+    base_attributes.merge({
+      user_id:    123,
+      project_id: 456,
+      event_time: mid_time,
+    })
+  end
+  let!(:events_type_0) { create_list(:event, 3, **attributes_type_0) }
 
-    context 'when there are no matching events' do
-      it 'returns no events' do
-        result_data = result["data"]
-        expect(result_data).not_to be_nil
-        expect(result_data[query_name]).to be_empty
-      end
-    end
-
-    context 'when there are matching events' do
-      let!(:events_type_1) { create_list(:event, 3, **attributes_type_1) }
-      it 'returns correct events' do
-        expect(result["data"][query_name]).to eq(output)
-      end
+  context 'when there are no matching events' do
+    it 'returns no events' do
+      result_data = result["data"]
+      expect(result_data).not_to be_nil
+      expect(result_data[query_name]).to be_empty
     end
   end
+
+  context 'when there are matching events' do
+    let!(:events_type_1) { create_list(:event, 1, **attributes_type_1) }
+    let!(:events_type_2) { create_list(:event, 2, **attributes_type_2) }
+    it 'returns correct events' do
+      expect(result["data"][query_name]).to eq(output)
+    end
+  end
+end
 
 Rspec.describe ZooStatsSchema do
   describe 'userIdQuery' do
     query_name = 'userIdQuery'
     users_id = 123
     query_string = "{
-        userIdQuery(userId: #{users_id}){
-          userId
-        }
-    }"
-    output = [
-      {"userId"=>"123"},
-      {"userId"=>"123"},
-      {"userId"=>"123"}
-    ]
-    it_behaves_like 'a graphQL query', query_name, query_string, output
+      userIdQuery(userId: #{users_id}){
+        userId
+      }
+      }"
+      output = [
+        {"userId"=>"123"},
+        {"userId"=>"123"},
+        {"userId"=>"123"}
+      ]
+      it_behaves_like 'a graphQL query', query_name, query_string, output
   end
-
+    
   describe 'projectIdQuery' do
     query_name = 'projectIdQuery'
     projects_id = 456
@@ -74,11 +86,29 @@ Rspec.describe ZooStatsSchema do
       projectIdQuery(projectId: #{projects_id}){
         projectId
       }
+      }"
+      output = [
+        {"projectId"=>"456"},
+        {"projectId"=>"456"},
+        {"projectId"=>"456"}
+      ]
+      it_behaves_like 'a graphQL query', query_name, query_string, output
+  end
+      
+  describe 'userBucketQuery' do
+    query_name = 'userBucketQuery'
+    user_id = 123
+    event_type = 'classification'
+    time_bucket = '1 day'
+    query_string = "{
+      userBucketQuery(userId: #{user_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
+        bucket,
+        count
+      }
     }"
     output = [
-      {"projectId"=>"456"},
-      {"projectId"=>"456"},
-      {"projectId"=>"456"}
+      {"bucket"=>"2018-11-06T00:00:00Z", "count"=>1},
+      {"bucket"=>"2018-11-08T00:00:00Z", "count"=>2}
     ]
     it_behaves_like 'a graphQL query', query_name, query_string, output
   end

--- a/spec/graphql/zoo_stats_schema_spec.rb
+++ b/spec/graphql/zoo_stats_schema_spec.rb
@@ -95,13 +95,13 @@ Rspec.describe ZooStatsSchema do
       it_behaves_like 'a graphQL query', query_name, query_string, output
   end
       
-  describe 'userBucketQuery' do
-    query_name = 'userBucketQuery'
+  describe 'userStatsCount' do
+    query_name = 'userStatsCount'
     user_id = 123
     event_type = 'classification'
     time_bucket = '1 day'
     query_string = "{
-      userBucketQuery(userId: #{user_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
+      userStatsCount(userId: #{user_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
         period,
         count
       }
@@ -113,13 +113,13 @@ Rspec.describe ZooStatsSchema do
     it_behaves_like 'a graphQL query', query_name, query_string, output
   end
 
-  describe 'projectBucketQuery' do
-    query_name = 'projectBucketQuery'
+  describe 'projectStatsCount' do
+    query_name = 'projectStatsCount'
     project_id= 456
     event_type = 'classification'
     time_bucket = '1 day'
     query_string = "{
-      projectBucketQuery(projectId: #{project_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
+      projectStatsCount(projectId: #{project_id}, eventType: \"#{event_type}\", timeBucket: \"#{time_bucket}\"){
         period,
         count
       }


### PR DESCRIPTION
Add time-bucket query for graphql. Variables either projectId or userId, then eventType and timeBucket for bucketing 

Tested with GraphiQL
Example Input:
```graphql
query {
  userBucketQuery(userId: 314552, eventType: "classification", timeBucket: "1 day"){
    bucket
    count
  }
}
```
Output:
```graphql
{
  "data": {
    "userBucketQuery": [
      {
        "bucket": "2018-11-05T00:00:00Z",
        "count": 1
      },
      {
        "bucket": "2018-11-06T00:00:00Z",
        "count": 3
      },
      {
        "bucket": "2018-11-07T00:00:00Z",
        "count": 1
      }
    ]
  }
}
```